### PR TITLE
UTF-8 breaks syntax highlighting

### DIFF
--- a/ruby-mode.el
+++ b/ruby-mode.el
@@ -163,14 +163,16 @@ Also ignores spaces after parenthesis when 'space."
     (erm-initialise)
     (throw 'interrupted t))
   (unless erm-ruby-process
-    (set-process-filter
-     (setq erm-ruby-process
-           (start-process "erm-ruby-process"
-                          nil
-                          enh-ruby-program (concat (file-name-directory (find-lisp-object-file-name 'erm-parse (symbol-function 'erm-parse))) "ruby/erm.rb")))
-     'erm-filter)
+    (setq erm-ruby-process
+          (start-process "erm-ruby-process"
+                         nil
+                         enh-ruby-program (concat (file-name-directory (find-lisp-object-file-name 'erm-parse (symbol-function 'erm-parse)))
+                                                  "ruby/erm.rb")))
+    (set-process-filter-multibyte erm-ruby-process t)
+    (set-process-coding-system erm-ruby-process 'utf-8 'utf-8)
+    (set-process-filter erm-ruby-process 'erm-filter)
     (set-process-query-on-exit-flag erm-ruby-process nil))
-  
+
   erm-ruby-process)
 
 (defvar erm-response nil "Private variable.")

--- a/ruby/erm.rb
+++ b/ruby/erm.rb
@@ -21,6 +21,8 @@ module Kernel
   end
 end
 
+STDIN.set_encoding("binary")
+
 File.open("/tmp/erm.out",'a') do |out|
   $fixme=out
   $fixme.puts "\n\nstarting\n\n"
@@ -32,7 +34,7 @@ File.open("/tmp/erm.out",'a') do |out|
     while c=STDIN.gets("\n\0\0\0\n")
       # $fixme.puts
       cmd=c[0].to_sym
-      args=c[1..-6].force_encoding("binary").split(':',6)
+      args=c[1..-6].split(':',6)
       buf=store.get_buffer(bn=args.shift.to_i)
       if cmd == :k
         store.rm(bn)
@@ -51,6 +53,7 @@ File.open("/tmp/erm.out",'a') do |out|
   rescue
     $fixme.puts $!.message
     $fixme.puts $!.backtrace
+    $fixme.flush
     puts "#{$!.message}: #{$!.backtrace.join("\n")}".inspect << "\n\0\0\0\n"
   end
 end

--- a/ruby/erm.rb
+++ b/ruby/erm.rb
@@ -32,7 +32,7 @@ File.open("/tmp/erm.out",'a') do |out|
     while c=STDIN.gets("\n\0\0\0\n")
       # $fixme.puts
       cmd=c[0].to_sym
-      args=c[1..-6].split(':',6)
+      args=c[1..-6].force_encoding("binary").split(':',6)
       buf=store.get_buffer(bn=args.shift.to_i)
       if cmd == :k
         store.rm(bn)

--- a/ruby/erm.rb
+++ b/ruby/erm.rb
@@ -21,7 +21,7 @@ module Kernel
   end
 end
 
-STDIN.set_encoding("binary")
+STDIN.set_encoding("UTF-8")
 
 File.open("/tmp/erm.out",'a') do |out|
   $fixme=out
@@ -51,6 +51,7 @@ File.open("/tmp/erm.out",'a') do |out|
       # $fixme.flush
     end
   rescue
+    $fixme.puts c.inspect
     $fixme.puts $!.message
     $fixme.puts $!.backtrace
     $fixme.flush


### PR DESCRIPTION
Hi there,

Having a file including UTF-8 characters breaks syntax highlighting.

If I create a file "test.rb" as follows:

```
# -*- coding: utf-8 -*-
"testöåä"
```

And try to open it, the code won't be highlighted.
