### PR TITLE
Update erm.rb to use environment ruby.

### DIFF
--- a/ruby/erm.rb
+++ b/ruby/erm.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 class BufferStore
   def initialize


### PR DESCRIPTION
This is dying for me since I am using rbenv to manage my rubies. I still have 1.8.7 on Mac OS X 10.8.4. This actually may be something that can be removed but I wasn't sure the interaction with Emacs.
